### PR TITLE
Sync with Google official build of Dawn and DXC

### DIFF
--- a/harnesses/dawn/patches/dawn_3de0f00.diff
+++ b/harnesses/dawn/patches/dawn_3de0f00.diff
@@ -574,6 +574,8 @@ index 0000000000..c9c85d6d95
 +
 +            arguments.push_back(L"-E");
 +            arguments.push_back(entryPointW.data());
++            arguments.push_back(L"-opt-disable");
++            arguments.push_back(L"structurize-loop-exits-for-unroll");
 +            arguments.push_back(L"/Gis");
 +            arguments.push_back(L"/Zpr");
 +            arguments.push_back(L"/enable-16bit-types");

--- a/harnesses/dxcompiler/README.md
+++ b/harnesses/dxcompiler/README.md
@@ -9,7 +9,7 @@ git submodule update
 cd DirectXShaderCompiler
 mkdir -p out/build
 cd out/build
-CC=/path/to/afl-clang-fast CXX=/path/to/afl-clang-fast++ cmake ../../ -C ../../cmake/caches/PredefinedParams.cmake -DCMAKE_BUILD_TYPE=Release -DDXC_DISABLE_ALLOCATOR_OVERRIDES=ON -DENABLE_SPIRV_CODEGEN=OFF -DSPIRV_BUILD_TESTS=OFF -DLLVM_USE_SANITIZER=Address -DLLVM_ENABLE_LTO=Off -G Ninja
+CC=/path/to/afl-clang-fast CXX=/path/to/afl-clang-fast++ cmake ../../ -C ../../cmake/caches/PredefinedParams.cmake -DCMAKE_BUILD_TYPE=Release -DDXC_DISABLE_ALLOCATOR_OVERRIDES=ON -DENABLE_SPIRV_CODEGEN=OFF -DSPIRV_BUILD_TESTS=OFF -DLLVM_USE_SANITIZER=Address -DLLVM_ENABLE_LTO=Off -DLLVM_ENABLE_ASSERTIONS=1 -G Ninja
 ninja
 
 # We now have libdxcompiler.so, which can be used with the dawn harness.


### PR DESCRIPTION
Hi! Recently I found that google has made some efforts to make DXC and Dawn much more robust after darthshader reports many dxc vulnerabilities! This is definitely an awesome work, nice job!
So I'm here to sync darthshader with the official build of DXC and Dawn.
Since:
1. dawn has disabled a buggy pass in their official build: https://github.com/google/dawn/blob/4628f0d8d1800b4d4a6c5e29c143f6dade6ebd50/src/dawn/native/d3d/ShaderUtils.cpp#L62
```
    // TODO(chromium:346595893): Disable buggy DXC pass
    arguments.push_back(L"-opt-disable");
    arguments.push_back(L"structurize-loop-exits-for-unroll");
```
2. DXC in chrome's non-debug release, it enabled the LLVM assertion to make it more robust: https://dawn-review.googlesource.com/c/dawn/+/199734. So I also added `-DLLVM_ENABLE_ASSERTIONS=1` to the dxc README.

These changes sync local configurations with the official Chrome settings, preventing the awkward situation where you discover a crash locally, eagerly submit it, only for developers to say it can't be reproduced in the latest Chrome release.