### PR TITLE
Define rustfmt.toml and format all code.

### DIFF
--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+style_edition = "2021"

--- a/src/lifter.rs
+++ b/src/lifter.rs
@@ -12,7 +12,7 @@ use libafl_bolts::AsSlice;
 
 mod ast;
 mod generator;
-mod ir; 
+mod ir;
 mod layeredinput;
 mod randomext;
 


### PR DESCRIPTION
This allows for deterministic formatting. All the code was already formatted, so the format step is a no-op.