### PR TITLE
Generate less debug symbols in release and debug modes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,12 +43,13 @@ cc = "*"
 lto = true
 codegen-units = 1
 opt-level = 3
-debug = true
+debug = 1
 rustflags = ["-C", "force-frame-pointers=yes"]
 panic = 'unwind'
 
 [profile.dev]
 panic = 'unwind'
+debug = 1
 
 [profile.dev.package.naga]
 opt-level = 3

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,2 @@
+edition = "2021"
+style_edition = "2021"

--- a/src/lifter.rs
+++ b/src/lifter.rs
@@ -12,7 +12,7 @@ use libafl_bolts::AsSlice;
 
 mod ast;
 mod generator;
-mod ir; 
+mod ir;
 mod layeredinput;
 mod randomext;
 


### PR DESCRIPTION
`debug = true` means `debug = 2`, which includes full debug info. For stack traces, we only need `debug = 1`.

Docs: https://doc.rust-lang.org/cargo/reference/profiles.html#debug

Based on PR #10. View diff here: https://github.com/wgslfuzz/darthshader/commit/2112cd4e613454bb5e88bc327ca93a03c3921054