### PR TITLE
Make darthshader a library crate, move main to new `fuzz` binary target.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,13 @@ version = "0.1.0"
 edition = "2021"
 rust-version = "1.77"
 
-[[bin]]
+[lib]
 name = "darthshader"
-path = "src/main.rs"
+path = "src/lib.rs"
+
+[[bin]]
+name = "fuzz"
+path = "src/bin/fuzz.rs"
 
 [[bin]]
 name = "lifter"

--- a/src/ast/mod.rs
+++ b/src/ast/mod.rs
@@ -1,4 +1,4 @@
-pub(crate) mod mutate;
+pub mod mutate;
 pub(crate) mod tree;
 
-pub(crate) use tree::Ast;
+pub use tree::Ast;

--- a/src/ast/mutate.rs
+++ b/src/ast/mutate.rs
@@ -15,6 +15,7 @@ use std::cmp;
 use crate::randomext::RandExt;
 use crate::{
     ast::tree::{ASTHandle, Cursor, NodeKind},
+    dictionary,
     layeredinput::LayeredInput,
 };
 
@@ -337,8 +338,7 @@ impl ASTReplaceTokenMutator {
     /// Creates a new [`ASTReplaceTokenMutator`].
     #[must_use]
     pub fn new() -> Self {
-        let s = include_str!("../dictionary.txt");
-        let token: Vec<String> = s.lines().map(|l| l.to_owned()).collect();
+        let token: Vec<String> = dictionary::strings().map(|s| s.to_owned()).collect();
         Self { token }
     }
 }

--- a/src/ast/tree.rs
+++ b/src/ast/tree.rs
@@ -12,17 +12,18 @@ use tinystr::TinyAsciiStr;
 use tinyvec::ArrayVec;
 use tree_sitter::{Language, Parser, TreeCursor};
 
+use crate::dictionary;
+
 extern "C" {
     fn tree_sitter_wgsl() -> Language;
 }
 
 static ATOMS: LazyLock<[&'static str; 301]> = LazyLock::new(|| {
-    let s = include_str!("../dictionary.txt");
-    let mut token: Vec<&'static str> = s.lines().collect();
+    let mut token: Vec<&'static str> = dictionary::strings().collect();
     token.sort();
     token
         .try_into()
-        .expect("Lenght of array must match length of dictionary.txt")
+        .expect("Length of array must match size of dictionary.")
 });
 
 static WGSLLANGUAGE: LazyLock<Language> = LazyLock::new(|| unsafe { tree_sitter_wgsl() });

--- a/src/bin/fuzz.rs
+++ b/src/bin/fuzz.rs
@@ -1,16 +1,3 @@
-#![feature(variant_count)]
-#![deny(
-    clippy::correctness,
-    clippy::cast_possible_wrap,
-    unused_lifetimes,
-    unused_unsafe,
-    single_use_lifetimes,
-    missing_debug_implementations
-)]
-#![recursion_limit = "256"]
-
-extern crate link_cplusplus;
-
 use mimalloc::MiMalloc;
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -55,25 +42,17 @@ use libafl_bolts::{
 
 use nix::sys::signal::Signal;
 
-mod ast;
-mod dictionary;
-mod exit;
-mod generator;
-mod ir;
-mod ladder;
-mod layeredinput;
-mod minimizer;
-mod randomext;
-
-use crate::generator::{GeneratorConfig, IRGenerator};
-use crate::{
+// Library imports
+use darthshader::generator::{GeneratorConfig, IRGenerator};
+use darthshader::{
     ast::mutate::ast_mutations,
+    dictionary,
     exit::{ExitFeedback, ExitObserver},
     ir::mutate::ir_mutations,
     ladder::LadderStage,
+    layeredinput::LayeredInput,
     minimizer::LayeredMinimizerStage,
 };
-use layeredinput::LayeredInput;
 
 pub fn main() {
     let res = Command::new(env!("CARGO_PKG_NAME"))
@@ -371,9 +350,12 @@ fn fuzz(
     let mut executor = TimeoutForkserverExecutor::with_signal(forkserver, timeout, Signal::SIGKILL)
         .expect("Failed to create the executor.");
 
-    std::mem::drop(shmap_to_drop);
-    std::mem::drop(shexit_to_drop);
-    std::mem::drop(shinput_to_drop);
+    #[allow(clippy::drop_copy)]
+    {
+        std::mem::drop(shmap_to_drop);
+        std::mem::drop(shexit_to_drop);
+        std::mem::drop(shinput_to_drop);
+    }
 
     state.add_metadata(dictionary::tokens());
 

--- a/src/dictionary.rs
+++ b/src/dictionary.rs
@@ -1,0 +1,18 @@
+use core::iter::Iterator;
+
+use libafl::mutators::Tokens;
+
+const DICTIONARY: &'static str = include_str!("dictionary.txt");
+
+/// Returns an iterator over all the strings in the dictionary.
+pub fn strings() -> impl Iterator<Item = &'static str> {
+    DICTIONARY.lines()
+}
+
+/// Builds a dictionary of interesting tokens for use in fuzzing.
+pub fn tokens() -> Tokens {
+    let mut tokens = Tokens::new();
+    tokens.add_tokens(strings().map(|s| s.as_bytes().to_vec()));
+    assert!(!tokens.is_empty());
+    tokens
+}

--- a/src/generator/config.rs
+++ b/src/generator/config.rs
@@ -51,7 +51,7 @@ impl MinMax<u32> {
 
 #[derive(Deserialize, Debug)]
 #[serde(rename_all(deserialize = "camelCase"))]
-pub(crate) struct GeneratorConfig {
+pub struct GeneratorConfig {
     pub global_const_exprs_count: MinMax<u32>,
     pub global_variables_count: MinMax<u32>,
     pub functions_count: MinMax<u32>,
@@ -66,17 +66,17 @@ pub(crate) struct GeneratorConfig {
 }
 
 #[derive(Debug)]
-pub(crate) struct ExpressionWeightMap {
+pub struct ExpressionWeightMap {
     pub weights: [u32; std::mem::variant_count::<ExpressionGenerators>()],
 }
 
 #[derive(Debug)]
-pub(crate) struct ConstExpressionWeightMap {
+pub struct ConstExpressionWeightMap {
     pub weights: [u32; std::mem::variant_count::<ConstExpressionGenerators>()],
 }
 
 #[derive(Debug)]
-pub(crate) struct StatementWeightMap {
+pub struct StatementWeightMap {
     pub weights: [u32; std::mem::variant_count::<StatementGenerators>()],
 }
 

--- a/src/generator/mod.rs
+++ b/src/generator/mod.rs
@@ -3,6 +3,6 @@ mod expression;
 mod generateir;
 mod statement;
 
-pub(crate) use config::GeneratorConfig;
+pub use config::GeneratorConfig;
 pub(crate) use generateir::FunctionGenCtx;
-pub(crate) use generateir::IRGenerator;
+pub use generateir::IRGenerator;

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -2,4 +2,4 @@ pub(crate) mod exprscope;
 pub(crate) mod funcext;
 pub(crate) mod iter;
 pub(crate) mod minimizer;
-pub(crate) mod mutate;
+pub mod mutate;

--- a/src/layeredinput.rs
+++ b/src/layeredinput.rs
@@ -13,7 +13,7 @@ use crate::ast::Ast;
 use crate::ir::iter::{BlockVisitorMut, FunctionIdentifier, IterFuncs};
 
 #[derive(Serialize, Deserialize, Clone, Debug)]
-pub(crate) struct IR {
+pub struct IR {
     module: naga::Module,
     #[serde(skip)]
     text: OnceCell<Result<String, String>>,
@@ -73,14 +73,14 @@ impl IR {
             .as_ref()
     }
 
-    pub fn get_func(&self, fid: FunctionIdentifier) -> &Function {
+    pub(crate) fn get_func(&self, fid: FunctionIdentifier) -> &Function {
         match fid {
             FunctionIdentifier::Function(handle) => &self.get_module().functions[handle],
             FunctionIdentifier::EntryPoint(idx) => &self.get_module().entry_points[idx].function,
         }
     }
 
-    pub fn get_func_mut(&mut self, fid: FunctionIdentifier) -> &mut Function {
+    pub(crate) fn get_func_mut(&mut self, fid: FunctionIdentifier) -> &mut Function {
         match fid {
             FunctionIdentifier::Function(handle) => &mut self.get_module_mut().functions[handle],
             FunctionIdentifier::EntryPoint(idx) => {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,0 +1,22 @@
+#![feature(variant_count)]
+#![deny(
+    clippy::correctness,
+    clippy::cast_possible_wrap,
+    unused_lifetimes,
+    unused_unsafe,
+    single_use_lifetimes,
+    missing_debug_implementations
+)]
+#![recursion_limit = "256"]
+
+extern crate link_cplusplus;
+
+pub mod ast;
+pub mod exit;
+pub mod dictionary;
+pub mod generator;
+pub mod ir;
+pub mod ladder;
+pub mod layeredinput;
+pub mod minimizer;
+pub mod randomext;

--- a/src/lifter.rs
+++ b/src/lifter.rs
@@ -1,21 +1,11 @@
-#![feature(lazy_cell)]
 #![feature(variant_count)]
-
-extern crate link_cplusplus;
 
 use std::{fs, path::PathBuf};
 
 use clap::{Arg, Command};
-use layeredinput::LayeredInput;
+use darthshader::layeredinput::LayeredInput;
 use libafl::prelude::HasTargetBytes;
 use libafl_bolts::AsSlice;
-
-mod ast;
-mod dictionary;
-mod generator;
-mod ir;
-mod layeredinput;
-mod randomext;
 
 pub fn main() {
     let res = Command::new(env!("CARGO_PKG_NAME"))

--- a/src/lifter.rs
+++ b/src/lifter.rs
@@ -11,6 +11,7 @@ use libafl::prelude::HasTargetBytes;
 use libafl_bolts::AsSlice;
 
 mod ast;
+mod dictionary;
 mod generator;
 mod ir;
 mod layeredinput;

--- a/src/main.rs
+++ b/src/main.rs
@@ -35,7 +35,7 @@ use libafl::{
     fuzzer::{Fuzzer, StdFuzzer},
     inputs::Input,
     monitors::SimpleMonitor,
-    mutators::{StdMOptMutator, Tokens},
+    mutators::StdMOptMutator,
     observers::{HitcountsMapObserver, StdMapObserver, TimeObserver},
     prelude::{forkserver::HasForkserver, CorpusId},
     schedulers::{
@@ -56,6 +56,7 @@ use libafl_bolts::{
 use nix::sys::signal::Signal;
 
 mod ast;
+mod dictionary;
 mod exit;
 mod generator;
 mod ir;
@@ -374,15 +375,7 @@ fn fuzz(
     std::mem::drop(shexit_to_drop);
     std::mem::drop(shinput_to_drop);
 
-    let tokens = {
-        let s = include_str!("dictionary.txt");
-        let v: Vec<Vec<u8>> = s.lines().map(|l| l.as_bytes().to_vec()).collect();
-        let mut tokens = Tokens::new();
-        tokens.add_tokens(v.iter());
-        assert!(!tokens.is_empty());
-        tokens
-    };
-    state.add_metadata(tokens);
+    state.add_metadata(dictionary::tokens());
 
     if let Some(mut seed_dir) = seed_dir {
         seed_dir.push("**/*");


### PR DESCRIPTION
This allows using darthshader in other modes than as a driver for an afl++-style out-of-process target.

Main changes:

* moves all logic from `src/main.rs` to `src/bin/fuzz.rs`
* exposes a few more types and modules beyond the `darthshader` crate

Builds off #15: [diff](https://github.com/wgslfuzz/darthshader/pull/12/changes/ceb1b3d9f9037cb065df4b1219e3106282aaa35a)