### PR TITLE
Use log crate instead of println.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,6 +36,7 @@ tinyvec = { version = "1", features = ["serde"] }
 tinystr = { version = "0.7", features = ["serde"] }
 bitflags = "1"
 smallvec = "1"
+log = "0.4"
 
 [build-dependencies]
 cc = "*"

--- a/darthshader-afl/src/main.rs
+++ b/darthshader-afl/src/main.rs
@@ -260,9 +260,8 @@ fn fuzz(
         shexit.write_to_env("__LIBAFL_EXIT_ID").unwrap();
     }
 
-    let edges_observer = unsafe {
-        HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_buf))
-    };
+    let edges_observer =
+        unsafe { HitcountsMapObserver::new(StdMapObserver::new("shared_mem", shmem_buf)) };
 
     let edges_observer = edges_observer.track_indices().track_novelties();
 

--- a/darthshader-afl/src/main.rs
+++ b/darthshader-afl/src/main.rs
@@ -38,6 +38,7 @@ use libafl_bolts::{
     rands::{Rand, StdRand},
     shmem::{unix_shmem::UnixShMem, ShMem, ShMemProvider, UnixShMemProvider},
     tuples::{tuple_list, Handled},
+    SimpleStdoutLogger,
     StdTargetArgs,
 };
 
@@ -56,6 +57,8 @@ use darthshader::{
 };
 
 pub fn main() {
+    SimpleStdoutLogger::set_logger().unwrap();
+
     let res = Command::new(env!("CARGO_PKG_NAME"))
         .version(env!("CARGO_PKG_VERSION"))
         .author("Lukas Bernhard")

--- a/src/ast/tree.rs
+++ b/src/ast/tree.rs
@@ -7,6 +7,7 @@ use std::{
     sync::LazyLock,
 };
 
+use log::debug;
 use serde::{Deserialize, Deserializer, Serialize, Serializer};
 use tinystr::TinyAsciiStr;
 use tinyvec::ArrayVec;
@@ -111,7 +112,7 @@ impl From<&str> for NodeText {
         } else if let Ok(index) = ATOMS.binary_search(&value) {
             NodeText::Atom(ATOMS[index])
         } else {
-            println!("hashing: {}", value);
+            debug!("hashing: {}", value);
             let mut hasher = DefaultHasher::new();
             value.hash(&mut hasher);
             let trunc = format!("trunc_{}", hasher.finish() as u32);

--- a/src/generator/generateir.rs
+++ b/src/generator/generateir.rs
@@ -6,6 +6,7 @@ use libafl_bolts::{
     rands::{Rand, StdRand},
     Error, Named,
 };
+use log::error;
 use naga::{
     valid::{ShaderStages, TypeFlags},
     AddressSpace, ArraySize, Binding, Block, BuiltIn, EntryPoint, Expression, Function,
@@ -1198,7 +1199,7 @@ where
         let text = match ir.try_get_text() {
             Ok(text) => text,
             Err(err) => {
-                println!("Generator built invalid file: {}", err);
+                error!("Generator built invalid file: {}", err);
                 let ast = Ast::try_from_wgsl("".as_bytes()).unwrap();
                 return Ok(LayeredInput::Ast(ast));
             }

--- a/src/generator/statement.rs
+++ b/src/generator/statement.rs
@@ -397,7 +397,7 @@ struct CallGenerator;
 impl StatementGenerator for CallGenerator {
     fn generate(ctx: &mut FunctionGenCtx, _: u32) -> Option<(Statement, u32)> {
         let Some(&function) = ctx.rng.choose(&ctx.available_funcs) else {
-            return None
+            return None;
         };
 
         let callee = &ctx.module.functions[function];

--- a/src/ir/debug.rs
+++ b/src/ir/debug.rs
@@ -1,0 +1,15 @@
+use core::fmt::{Display, Error as FmtError, Formatter};
+
+use naga::{Arena, Expression};
+
+/// Newtype for lazily printing expressions in case of error.
+pub struct ExpressionsPrinter<'a>(pub &'a Arena<Expression>);
+
+impl Display for ExpressionsPrinter<'_> {
+    fn fmt(&self, fmt: &mut Formatter<'_>) -> Result<(), FmtError> {
+        for (handle, expr) in self.0.iter() {
+            write!(fmt, "\n{:?} {:?}", handle, expr)?
+        }
+        Ok(())
+    }
+}

--- a/src/ir/exprscope.rs
+++ b/src/ir/exprscope.rs
@@ -6,7 +6,7 @@ use naga::{
 };
 use rand::{rngs::SmallRng, seq::IteratorRandom, Rng, SeedableRng};
 
-use crate::ir::iter::FunctionIdentifier;
+use crate::ir::{debug::ExpressionsPrinter, iter::FunctionIdentifier};
 
 use super::iter::UsesExprIter;
 
@@ -77,10 +77,11 @@ impl BestEffortTypifier {
                 }
             }
             if work_done > expressions.len() * 2 {
-                for (eh, expr) in expressions.iter() {
-                    println!("{:?} {:?}", eh, expr);
-                }
-                panic!("Expressions contain a cycle when adding {:?}", expr_handle);
+                panic!(
+                    "Expressions contain a cycle when adding {:?}: {}",
+                    expr_handle,
+                    ExpressionsPrinter(expressions)
+                );
             }
         }
     }

--- a/src/ir/funcext.rs
+++ b/src/ir/funcext.rs
@@ -1,6 +1,37 @@
+use log::error;
 use naga::{Expression, Function, Handle, RayQueryFunction, Statement};
 
-use crate::ir::iter::{StatementVisitor, UsesExprIter};
+use crate::ir::{
+    debug::ExpressionsPrinter,
+    iter::{StatementVisitor, UsesExprIter},
+};
+
+fn log_err(func: &Function) {
+    error!("failing graph: {}", ExpressionsPrinter(&func.expressions));
+}
+
+fn is_cyclic(
+    func: &Function,
+    handle: Handle<Expression>,
+    in_stack: &mut Vec<bool>,
+    done: &mut Vec<bool>,
+) -> bool {
+    if done[handle.index()] {
+        return false;
+    }
+    in_stack[handle.index()] = true;
+    for used_handle in func.expressions[handle].iter_used_exprs() {
+        if in_stack[used_handle.index()] {
+            return true;
+        }
+        if is_cyclic(func, used_handle, in_stack, done) {
+            return true;
+        }
+    }
+    in_stack[handle.index()] = false;
+    done[handle.index()] = true;
+    false
+}
 
 pub trait FuncExt {
     fn validate_dag(&self) -> Result<(), ()>;
@@ -10,36 +41,6 @@ impl FuncExt for Function {
     fn validate_dag(&self) -> Result<(), ()> {
         let mut done = vec![false; self.expressions.len()];
         let mut in_stack = vec![false; self.expressions.len()];
-
-        fn log_err(func: &Function) {
-            println!("failing graph:");
-            for (handle, expr) in func.expressions.iter() {
-                println!("{:?} {:?}", handle, expr);
-            }
-        }
-
-        fn is_cyclic(
-            func: &Function,
-            handle: Handle<Expression>,
-            in_stack: &mut Vec<bool>,
-            done: &mut Vec<bool>,
-        ) -> bool {
-            if done[handle.index()] {
-                return false;
-            }
-            in_stack[handle.index()] = true;
-            for used_handle in func.expressions[handle].iter_used_exprs() {
-                if in_stack[used_handle.index()] {
-                    return true;
-                }
-                if is_cyclic(func, used_handle, in_stack, done) {
-                    return true;
-                }
-            }
-            in_stack[handle.index()] = false;
-            done[handle.index()] = true;
-            false
-        }
 
         for (handle, _) in self.expressions.iter() {
             if is_cyclic(self, handle, &mut in_stack, &mut done) {

--- a/src/ir/mod.rs
+++ b/src/ir/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod debug;
 pub(crate) mod exprscope;
 pub(crate) mod funcext;
 pub(crate) mod iter;

--- a/src/ladder.rs
+++ b/src/ladder.rs
@@ -2,9 +2,6 @@
 
 use core::{fmt::Debug, marker::PhantomData};
 
-use libafl_bolts::impl_serdeany;
-use serde::{Deserialize, Serialize};
-
 use libafl::{
     common::{HasMetadata, HasNamedMetadata},
     corpus::{Corpus, CorpusId, HasCurrentCorpusId, Testcase},
@@ -15,6 +12,9 @@ use libafl::{
     state::{HasClientPerfMonitor, HasCorpus, HasCurrentTestcase, HasRand},
     Error, HasScheduler,
 };
+use libafl_bolts::impl_serdeany;
+use log::debug;
+use serde::{Deserialize, Serialize};
 
 use crate::{
     ast::Ast,
@@ -120,13 +120,13 @@ where
         }
 
         let id = state.current_corpus_id()?.unwrap();
-        println!("scheduling for ladder {}", id);
+        debug!("scheduling for ladder {}", id);
 
         let input = state.current_input_cloned()?;
 
         match input {
             LayeredInput::IR(ir) => {
-                println!("IR ladder");
+                debug!("IR ladder");
                 if may_descend(&*state.current_testcase().unwrap()) {
                     let Ok(text) = ir.try_get_text() else {
                         return Ok(());
@@ -154,7 +154,7 @@ where
                         Self::prohibit_descend(state, nidx);
                     }
                 } else {
-                    println!("not allowed to accend");
+                    debug!("not allowed to accend");
                 }
             }
         };

--- a/src/layeredinput.rs
+++ b/src/layeredinput.rs
@@ -9,6 +9,7 @@ use libafl::{
     Error,
 };
 use libafl_bolts::{ownedref::OwnedSlice, HasLen};
+use log::debug;
 use naga::{
     back::wgsl::Writer, Block, Expression, Function, Handle, Range, ScalarKind, Statement, Type,
     TypeInner,
@@ -273,7 +274,7 @@ impl Input for LayeredInput {
     where
         P: AsRef<Path>,
     {
-        println!("from file {:?}", path.as_ref());
+        debug!("from file: {:?}", path.as_ref());
 
         let input = fs::read(path.as_ref())?;
         let input = String::from_utf8(input)?;
@@ -317,7 +318,7 @@ impl Input for LayeredInput {
                 });
 
                 let Ok(Ok(module)) = res else {
-                    println!("Attempting to parse as AST: {:?}", path.as_ref());
+                    debug!("Attempting to parse as AST: {:?}", path.as_ref());
                     let ast = match Ast::try_from_wgsl(input.as_bytes()) {
                         Ok(ast) => ast,
                         Err(_) => Ast::try_from_wgsl("".as_bytes()).unwrap(),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,8 +12,8 @@
 extern crate link_cplusplus;
 
 pub mod ast;
-pub mod exit;
 pub mod dictionary;
+pub mod exit;
 pub mod generator;
 pub mod ir;
 pub mod ladder;

--- a/src/minimizer.rs
+++ b/src/minimizer.rs
@@ -1,10 +1,4 @@
 use core::{fmt::Debug, marker::PhantomData};
-
-use libafl_bolts::{
-    tuples::{Handle, MatchNameRef, NamedTuple},
-    AsSlice, HasLen,
-};
-use serde::{Deserialize, Serialize};
 use std::collections::HashSet;
 
 use libafl::{
@@ -20,6 +14,12 @@ use libafl::{
     state::{HasClientPerfMonitor, HasCorpus, HasCurrentTestcase, HasExecutions, HasRand},
     Error,
 };
+use libafl_bolts::{
+    tuples::{Handle, MatchNameRef, NamedTuple},
+    AsSlice, HasLen,
+};
+use log::{debug, warn};
+use serde::{Deserialize, Serialize};
 
 use crate::{
     ast::{mutate::ASTDeleteMutator, Ast},
@@ -73,7 +73,7 @@ where
                     assert!(func.validate_dag().is_ok());
                 }
                 if let Err(err) = ir.try_get_text() {
-                    println!(
+                    warn!(
                         "Minimizer {} broke sample: {}",
                         minimizers.name(rand_idx).unwrap(),
                         err
@@ -214,7 +214,7 @@ where
         let mut stable_novelties: Vec<usize> =
             novelties.difference(&unstable_entries).cloned().collect();
         stable_novelties.sort();
-        println!(
+        debug!(
             "{} has {} unstable entries, {} stable entries",
             state.current_corpus_id().unwrap().unwrap(),
             unstable_entries.len(),
@@ -232,13 +232,13 @@ where
                 LayeredInput::Ast(_) => self.minimize_ast(state, &smallest),
             };
             let Some(mutated) = mutated else {
-                println!("warning: mutator failed to mutate");
+                warn!("mutator failed to mutate");
                 continue;
             };
 
             executor.observers_mut().pre_exec_all(state, &mutated)?;
             if executor.run_target(fuzzer, state, mgr, &mutated)? != exit_kind {
-                println!("warning: mutation changed exit_kind, discarding");
+                warn!("mutation changed exit_kind, discarding");
                 continue;
             }
 
@@ -255,8 +255,9 @@ where
             }
 
             if mutated.len() >= smallest_size {
-                println!(
-                    "warning: minimizer didn't produce smaller sample {} vs {}",
+                warn!(
+                    "warning: minimizer didn't produce smaller sample {} vs
+                 {}",
                     mutated.len(),
                     smallest_size
                 );


### PR DESCRIPTION
This allows users of the `darthshader` crate to make their own choices about what gets logged and how.

Builds on #16: [diff](https://github.com/wgslfuzz/darthshader/pull/17/changes/e4e99b5e0969a3a0691a3568659e9180b434cf4a)