### PR TITLE
Correct reference to darthshader-afl in README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DarthShader is a fuzzer for fuzzing the WebGPU shader compilation pipeline in we
 The usage of DarthShader is best explained by its `--help` switch:
 
 ```console
-Usage: darthshader [OPTIONS] --output <out> <exec> [-- [arguments]...]
+Usage: darthshader-afl [OPTIONS] --output <out> <exec> [-- [arguments]...]
 
 Arguments:
   <exec>          The instrumented binary we want to fuzz


### PR DESCRIPTION
Now that the CLI for AFL++-compatible targets has moved to the `darthshader-afl` crate.