### PR TITLE
Specify cc dependency version.

### DIFF
--- a/darthshader/Cargo.toml
+++ b/darthshader/Cargo.toml
@@ -35,4 +35,4 @@ tinyvec = { version = "1", features = ["serde"] }
 tree-sitter = "0.21"
 
 [build-dependencies]
-cc = "*"
+cc = "1.2"


### PR DESCRIPTION
Wildcard crate dependencies are not allowed on crates.io.